### PR TITLE
Added "Show recent apps" app shortcut

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -20,7 +20,17 @@
                 <action android:name="android.intent.action.MAIN" />
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
+            <meta-data
+                android:name="android.app.shortcuts"
+                android:resource="@xml/shortcuts" />
         </activity>
+
+        <activity
+            android:name=".TriggerActivity"
+            android:exported="true"
+            android:excludeFromRecents="true"
+            android:taskAffinity=""
+            android:theme="@android:style/Theme.NoDisplay" />
 
         <service
             android:name=".MainService"

--- a/app/src/main/java/com/crispim/recentapps/MainActivity.kt
+++ b/app/src/main/java/com/crispim/recentapps/MainActivity.kt
@@ -229,19 +229,20 @@ class MainActivity : ComponentActivity() {
                 Text(text = "Buy me an Ice Cream ($1)")
             }
 
-            OutlinedButton(
-                onClick = {
-                    val url = "https://github.com/crispim1411/RecentApps/issues"
-                    val intent = Intent(Intent.ACTION_VIEW, url.toUri())
-                    context.startActivity(intent)
-                },
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .height(56.dp),
-                shape = RoundedCornerShape(16.dp),
-            ) {
-                Text(text = "A Bug? Report it!")
+            val version = remember {
+                try {
+                    context.packageManager.getPackageInfo(context.packageName, 0).versionName
+                } catch (_: Exception) {
+                    "1.0.0"
+                }
             }
+
+            Text(
+                text = "Version $version",
+                style = MaterialTheme.typography.bodySmall,
+                color = Color.Gray,
+                modifier = Modifier.padding(bottom = 8.dp)
+            )
 
             Spacer(modifier = Modifier.height(16.dp))
         }

--- a/app/src/main/java/com/crispim/recentapps/MainService.kt
+++ b/app/src/main/java/com/crispim/recentapps/MainService.kt
@@ -2,22 +2,13 @@ package com.crispim.recentapps
 
 import android.accessibilityservice.AccessibilityService
 import android.annotation.SuppressLint
-import android.app.ActivityOptions
-import android.content.ComponentName
 import android.content.Intent
-import android.hardware.display.DisplayManager
 import android.os.VibrationEffect
 import android.os.Vibrator
 import android.view.accessibility.AccessibilityEvent
 
 @SuppressLint("AccessibilityPolicy")
 class MainService : AccessibilityService() {
-    private lateinit var displayManager: DisplayManager
-
-    override fun onServiceConnected() {
-        super.onServiceConnected()
-        displayManager = getSystemService(DISPLAY_SERVICE) as DisplayManager
-    }
 
     override fun onAccessibilityEvent(event: AccessibilityEvent?) {
         if (event?.eventType == AccessibilityEvent.TYPE_VIEW_LONG_CLICKED) {
@@ -26,13 +17,20 @@ class MainService : AccessibilityService() {
                 val viewIdResourceName = sourceNode.viewIdResourceName
                 if (packageName == "com.android.systemui" && viewIdResourceName == "com.android.systemui:id/home") {
                     vibrate()
-                    openRecentApps()
+                    startTriggerActivity()
                 }
             }
         }
     }
 
     override fun onInterrupt() {}
+
+    private fun startTriggerActivity() {
+        val intent = Intent(this, TriggerActivity::class.java).apply {
+            addFlags(Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_NO_ANIMATION)
+        }
+        startActivity(intent)
+    }
 
     private fun vibrate() {
         getSystemService(Vibrator::class.java)?.let {
@@ -44,32 +42,6 @@ class MainService : AccessibilityService() {
                     )
                 )
             }
-        }
-    }
-
-    private fun openRecentApps() {
-        try {
-            val intent = Intent().apply {
-                component = ComponentName(
-                    "com.sec.android.app.launcher",
-                    "com.android.quickstep.RecentsActivity"
-                )
-                addFlags(Intent.FLAG_ACTIVITY_NEW_TASK or
-                        Intent.FLAG_ACTIVITY_CLEAR_TASK or
-                        Intent.FLAG_ACTIVITY_NO_HISTORY)
-            }
-
-            val options = ActivityOptions.makeBasic()
-            val coverDisplay = displayManager.getDisplay(1)
-
-            if (coverDisplay != null) {
-                options.launchDisplayId = coverDisplay.displayId
-                startActivity(intent, options.toBundle())
-            } else {
-                startActivity(intent)
-            }
-        } catch (e: Exception) {
-            e.printStackTrace()
         }
     }
 }

--- a/app/src/main/java/com/crispim/recentapps/TriggerActivity.kt
+++ b/app/src/main/java/com/crispim/recentapps/TriggerActivity.kt
@@ -25,11 +25,16 @@ class TriggerActivity : Activity() {
                     "com.sec.android.app.launcher",
                     "com.android.quickstep.RecentsActivity"
                 )
-                addFlags(Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_REORDER_TO_FRONT)
+                addFlags(
+                    Intent.FLAG_ACTIVITY_NEW_TASK or
+                            Intent.FLAG_ACTIVITY_CLEAR_TASK or
+                            Intent.FLAG_ACTIVITY_NO_HISTORY
+                )
             }
 
             val displayManager = getSystemService(Context.DISPLAY_SERVICE) as DisplayManager
             val options = ActivityOptions.makeBasic()
+            
             val coverDisplay = displayManager.getDisplay(1)
 
             if (coverDisplay != null) {

--- a/app/src/main/java/com/crispim/recentapps/TriggerActivity.kt
+++ b/app/src/main/java/com/crispim/recentapps/TriggerActivity.kt
@@ -1,0 +1,45 @@
+package com.crispim.recentapps
+
+import android.app.Activity
+import android.app.ActivityOptions
+import android.content.ComponentName
+import android.content.Context
+import android.content.Intent
+import android.hardware.display.DisplayManager
+import android.os.Bundle
+
+class TriggerActivity : Activity() {
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        
+        openRecentApps()
+        
+        finish()
+    }
+
+    private fun openRecentApps() {
+        try {
+            val intent = Intent().apply {
+                component = ComponentName(
+                    "com.sec.android.app.launcher",
+                    "com.android.quickstep.RecentsActivity"
+                )
+                addFlags(Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_REORDER_TO_FRONT)
+            }
+
+            val displayManager = getSystemService(Context.DISPLAY_SERVICE) as DisplayManager
+            val options = ActivityOptions.makeBasic()
+            val coverDisplay = displayManager.getDisplay(1)
+
+            if (coverDisplay != null) {
+                options.launchDisplayId = coverDisplay.displayId
+                startActivity(intent, options.toBundle())
+            } else {
+                startActivity(intent)
+            }
+        } catch (e: Exception) {
+            e.printStackTrace()
+        }
+    }
+}

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,4 +1,5 @@
 <resources>
     <string name="app_name">RecentApps</string>
     <string name="accessibility_service_description">RecentApps uses this service to detect user commands and quickly switch between recently opened applications.</string>
+    <string name="shortcut_recent_apps">Show recent apps</string>
 </resources>

--- a/app/src/main/res/xml/shortcuts.xml
+++ b/app/src/main/res/xml/shortcuts.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shortcuts xmlns:android="http://schemas.android.com/apk/res/android">
+    <shortcut
+        android:shortcutId="recent_apps"
+        android:enabled="true"
+        android:icon="@mipmap/recent_apps"
+        android:shortcutShortLabel="@string/shortcut_recent_apps"
+        android:shortcutLongLabel="@string/shortcut_recent_apps">
+        <intent
+            android:action="android.intent.action.VIEW"
+            android:targetPackage="com.crispim.recentapps"
+            android:targetClass="com.crispim.recentapps.TriggerActivity" />
+        <categories android:name="android.shortcut.conversation" />
+    </shortcut>
+</shortcuts>


### PR DESCRIPTION
- Created [TriggerActivity] to handle launching the recent apps intent and finishing itself.
- Defined a static app shortcut in [shortcuts.xml] targeting [TriggerActivity]

This allows triggering the recent apps screen through Samsung Routines or Tasker. Thus it's possible to achieve the same effect without having to use button navigation.
For example, you can create a new Samsung Routine that will be triggered on Volume Up double press, check if the phone is in the closed state, then launch this new recent apps activity.