### PR TITLE
Fix Recents not updating correctly on the cover screen

### DIFF
--- a/app/src/main/java/com/crispim/recentapps/MainService.kt
+++ b/app/src/main/java/com/crispim/recentapps/MainService.kt
@@ -54,7 +54,9 @@ class MainService : AccessibilityService() {
                     "com.sec.android.app.launcher",
                     "com.android.quickstep.RecentsActivity"
                 )
-                addFlags(Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_REORDER_TO_FRONT)
+                addFlags(Intent.FLAG_ACTIVITY_NEW_TASK or
+                        Intent.FLAG_ACTIVITY_CLEAR_TASK or
+                        Intent.FLAG_ACTIVITY_NO_HISTORY)
             }
 
             val options = ActivityOptions.makeBasic()


### PR DESCRIPTION
This PR fixes two issues:

1. Apps launched from the cover screen do not appear in Recents on the cover screen until Recents is opened on the inner screen.
2. Recommended apps in Recents on the inner screen do not appear immediately after opening Recents on the cover screen.


Root cause:

- The first issue appears to be caused by Recents being brought to the foreground in an unintended way instead of being recreated, preventing the app list from being refreshed.
- The second issue was caused by multiple Recents instances existing simultaneously.


Changes:

- Replaced `FLAG_ACTIVITY_REORDER_TO_FRONT` with `FLAG_ACTIVITY_CLEAR_TASK` to recreate Recents and refresh the app list correctly.
- Added `FLAG_ACTIVITY_NO_HISTORY` to prevent the cover-screen Recents activity from remaining in the back stack.

Tested on:
- Galaxy Z Flip7
- One UI 8.5